### PR TITLE
fix: use vim.uv.os_homedir() to resolve HOME (#19)

### DIFF
--- a/lua/yadm-git/yadm.lua
+++ b/lua/yadm-git/yadm.lua
@@ -2,6 +2,15 @@ local M = {}
 
 local logger = require "yadm-git.logger"
 
+-- Resolve the user's home directory.
+-- Prefer vim.uv.os_homedir() over $HOME because on immutable distros (Bazzite,
+-- etc.) $HOME points to the physical path (/var/home/user) while /etc/passwd —
+-- and vim.fn.fnamemodify(":p") — yields the symlink path (/home/user). See
+-- issue #19. Falls back to $HOME when libuv cannot determine it.
+local function get_home()
+  return vim.uv.os_homedir() or vim.env.HOME
+end
+
 -- Check if a .git directory or file exists in current path hierarchy (indicates regular git)
 local function has_local_git()
   -- Check for .git directory (regular repos)
@@ -17,12 +26,13 @@ end
 
 -- Get yadm repository path if it exists
 function M.get_yadm_repo_path()
-  if not vim.env.HOME then
-    logger.warn "HOME environment variable is not set"
+  local home = get_home()
+  if not home then
+    logger.warn "Could not determine home directory"
     return nil
   end
   -- Check modern location first (v3+)
-  local xdg_data = vim.env.XDG_DATA_HOME or (vim.env.HOME .. "/.local/share")
+  local xdg_data = vim.env.XDG_DATA_HOME or (home .. "/.local/share")
   local modern_path = xdg_data .. "/yadm/repo.git"
   if vim.fn.isdirectory(modern_path) == 1 then
     logger.debug("Found yadm repo at modern location: " .. modern_path)
@@ -30,7 +40,7 @@ function M.get_yadm_repo_path()
   end
 
   -- Check legacy location
-  local legacy_path = vim.env.HOME .. "/.yadm/repo.git"
+  local legacy_path = home .. "/.yadm/repo.git"
   if vim.fn.isdirectory(legacy_path) == 1 then
     logger.debug("Found yadm repo at legacy location: " .. legacy_path)
     return legacy_path
@@ -41,7 +51,7 @@ end
 
 -- Check if current directory is under HOME
 local function is_under_home()
-  local home = vim.env.HOME
+  local home = get_home()
   if not home then
     return false
   end
@@ -83,9 +93,10 @@ function M.setup_yadm_env()
     return
   end
 
+  local home = get_home()
   vim.env.GIT_DIR = yadm_repo
-  vim.env.GIT_WORK_TREE = vim.env.HOME
-  logger.info("Set GIT_DIR=" .. yadm_repo .. " GIT_WORK_TREE=" .. vim.env.HOME)
+  vim.env.GIT_WORK_TREE = home
+  logger.info("Set GIT_DIR=" .. yadm_repo .. " GIT_WORK_TREE=" .. home)
 end
 
 function M.clear_yadm_env()

--- a/tests/yadm_spec.lua
+++ b/tests/yadm_spec.lua
@@ -4,11 +4,13 @@ local stub = require "luassert.stub"
 describe("yadm-git.yadm", function()
   local orig_vim_fn
   local orig_vim_env
+  local orig_vim_uv
   local logger
 
   before_each(function()
     orig_vim_fn = vim.fn
     orig_vim_env = vim.env
+    orig_vim_uv = vim.uv
     logger = require "yadm-git.logger"
     stub(logger, "warn")
     stub(logger, "info")
@@ -28,11 +30,19 @@ describe("yadm-git.yadm", function()
       getcwd = stub(vim.fn, "getcwd"),
       fnamemodify = stub(vim.fn, "fnamemodify"),
     }
+
+    -- Mock vim.uv.os_homedir (defaults to same as HOME)
+    vim.uv = {
+      os_homedir = function()
+        return "/home/testuser"
+      end,
+    }
   end)
 
   after_each(function()
     vim.fn = orig_vim_fn
     vim.env = orig_vim_env
+    vim.uv = orig_vim_uv
     logger.warn:revert()
     logger.info:revert()
     logger.debug:revert()
@@ -91,6 +101,25 @@ describe("yadm-git.yadm", function()
       vim.fn.fnamemodify.returns "/tmp/test/"
 
       assert.is_false(yadm.is_yadm_managed())
+    end)
+
+    -- Regression: immutable distros (Bazzite, etc.) where $HOME points to the
+    -- physical path (/var/home/user) but /etc/passwd — and therefore
+    -- vim.fn.fnamemodify(":p") — yields the symlink path (/home/user).
+    -- vim.uv.os_homedir() agrees with passwd, so use that as the source of truth.
+    it("returns true on immutable distros where $HOME and passwd disagree", function()
+      vim.env.HOME = "/var/home/testuser"
+      vim.uv.os_homedir = function()
+        return "/home/testuser"
+      end
+
+      vim.fn.getcwd.returns "/home/testuser/.config/nvim"
+      vim.fn.finddir.on_call_with(".git", "/home/testuser/.config/nvim;").returns ""
+      vim.fn.findfile.on_call_with(".git", "/home/testuser/.config/nvim;").returns ""
+      vim.fn.isdirectory.on_call_with("/home/testuser/.local/share/yadm/repo.git").returns(1)
+      vim.fn.fnamemodify.returns "/home/testuser/.config/nvim/"
+
+      assert.is_true(yadm.is_yadm_managed())
     end)
   end)
 

--- a/tests/yadm_spec.lua
+++ b/tests/yadm_spec.lua
@@ -121,6 +121,22 @@ describe("yadm-git.yadm", function()
 
       assert.is_true(yadm.is_yadm_managed())
     end)
+
+    -- Regression: when libuv cannot determine the home directory, fall back to
+    -- $HOME so behavior is no worse than before the os_homedir switch.
+    it("falls back to $HOME when vim.uv.os_homedir() returns nil", function()
+      vim.uv.os_homedir = function()
+        return nil
+      end
+
+      vim.fn.getcwd.returns "/home/testuser/.config/nvim"
+      vim.fn.finddir.on_call_with(".git", "/home/testuser/.config/nvim;").returns ""
+      vim.fn.findfile.on_call_with(".git", "/home/testuser/.config/nvim;").returns ""
+      vim.fn.isdirectory.on_call_with("/home/testuser/.local/share/yadm/repo.git").returns(1)
+      vim.fn.fnamemodify.returns "/home/testuser/.config/nvim/"
+
+      assert.is_true(yadm.is_yadm_managed())
+    end)
   end)
 
   describe("setup_yadm_env", function()
@@ -161,6 +177,21 @@ describe("yadm-git.yadm", function()
       assert.stub(logger.warn).was_called_with "Could not find yadm repository"
       assert.is_nil(vim.env.GIT_DIR)
       assert.is_nil(vim.env.GIT_WORK_TREE)
+    end)
+
+    -- Regression: on immutable distros, GIT_WORK_TREE must follow os_homedir
+    -- (passwd value) rather than $HOME, matching how Neovim resolves paths.
+    it("sets GIT_WORK_TREE from os_homedir, not $HOME, when they disagree", function()
+      vim.env.HOME = "/var/home/testuser"
+      vim.uv.os_homedir = function()
+        return "/home/testuser"
+      end
+      vim.fn.isdirectory.on_call_with("/home/testuser/.local/share/yadm/repo.git").returns(1)
+
+      yadm.setup_yadm_env()
+
+      assert.equals("/home/testuser/.local/share/yadm/repo.git", vim.env.GIT_DIR)
+      assert.equals("/home/testuser", vim.env.GIT_WORK_TREE)
     end)
   end)
 


### PR DESCRIPTION
## Summary
- Fixes #19: yadm-git skipped activation on immutable distros (Bazzite, etc.) because `$HOME` (`/var/home/user`) and `vim.fn.fnamemodify(":p")` (which follows `/etc/passwd` → `/home/user`) disagree, so the `is_under_home()` startswith check spuriously failed.
- Introduces a `get_home()` helper that prefers `vim.uv.os_homedir()` and falls back to `$HOME`, and routes every former `vim.env.HOME` usage in `yadm.lua` through it for consistency (path comparison, repo lookup, `GIT_WORK_TREE`).

## Test plan
- [x] `make test` — all specs pass (added regression test simulating the Bazzite `$HOME` ≠ passwd scenario)
- [ ] Manual verification on a Bazzite / immutable Fedora system (deferred to reporter)